### PR TITLE
SCRM-59: Add EC2 instance with SSH/HTTP access and key pair

### DIFF
--- a/terraform/modules/ec2/data.tf
+++ b/terraform/modules/ec2/data.tf
@@ -1,0 +1,10 @@
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,47 @@
+resource "aws_security_group" "ec2_sg" {
+  name        = "ec2-sg"
+  description = "Allow SSH and HTTP"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "Allow SSH"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "Allow HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+resource "aws_key_pair" "ssh_key" {
+  key_name   = "my_key_pair"
+  public_key = file("~/.ssh/my_shh_key.pub")
+}
+
+
+resource "aws_instance" "web" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = "t2.micro"
+  key_name               = aws_key_pair.ssh_key.key_name
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [aws_security_group.ec2_sg.id]
+
+  tags = {
+    Name = "web-instance"
+  }
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,6 @@
+output "public_ip" {
+  value = aws_instance.web.public_ip
+}
+output "security_group_id" {
+  value = aws_security_group.ec2_sg.id
+}

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,2 @@
+variable "vpc_id" {}
+variable "subnet_id" {}


### PR DESCRIPTION
EC2 instance infrastructure has been implemented.

Includes:
- A security group allowing inbound SSH (port 22) and HTTP (port 80)
- An EC2 key pair referencing a local public key
- A `t2.micro` EC2 instance running the latest Ubuntu 22.04 AMI
- Deployed inside the public subnet passed as a variable

