### PR TITLE
SCRM-60: Add PostgreSQL RDS instance with subnet group and secure SG …

### DIFF
--- a/terraform/modules/rds/main.tf
+++ b/terraform/modules/rds/main.tf
@@ -1,0 +1,41 @@
+resource "aws_db_subnet_group" "rds" {
+  name       = "rds-subnet-group"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "RDS subnet group"
+  }
+}
+
+resource "aws_security_group" "rds_sg" {
+  name        = "rds-sg"
+  description = "Allow DB connections"
+  vpc_id      = var.vpc_id
+
+ ingress {
+  from_port   = 5432
+  to_port     = 5432
+  protocol    = "tcp"
+  security_groups = [var.ec2_sg_id] 
+ }
+
+ egress {
+  from_port   = 0
+  to_port     = 0
+  protocol    = "-1"
+  cidr_blocks = ["0.0.0.0/0"]
+ }
+}
+
+resource "aws_db_instance" "default" {
+  allocated_storage      = 20
+  engine                 = "postgres"
+  engine_version         = "15.3"
+  instance_class         = "db.t3.micro"
+  username               = "admin"
+  password               = var.db_password
+  db_subnet_group_name   = aws_db_subnet_group.rds.name
+  vpc_security_group_ids = [aws_security_group.rds_sg.id]
+  skip_final_snapshot    = true
+}
+

--- a/terraform/modules/rds/outputs.tf
+++ b/terraform/modules/rds/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = aws_db_instance.default.endpoint
+}

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -1,0 +1,12 @@
+variable "vpc_id" {}
+variable "subnet_ids" {
+  type = list(string)
+}
+variable "db_password" {
+  description = "Password for the RDS PostgreSql instance"
+  sensitive   = true
+}
+
+variable "ec2_sg_id" {
+  description = "Security group ID of EC2 instance"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,3 @@
+output "endpoint" {
+  value = aws_db_instance.default.endpoint
+}


### PR DESCRIPTION
 RDS PostgreSQL infrastructure is implemented.

Includes:

A private DB subnet group referencing multiple private subnets

A secure RDS security group that only allows traffic from the EC2 instance

A db.t3.micro PostgreSQL 15.3 instance with 20GB storage

Password is injected via Terraform variable, add to .gitignore

Instance is isolated within the private subnet and ready for use by the Flask application.