### PR TITLE
SCRM-68: Configure root module to integrate VPC, EC2, and RDS modules

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,42 @@
+# Terraform AWS Infrastructure
+
+This Terraform configuration deploys a basic infrastructure in AWS that includes:
+
+- A Virtual Private Cloud (VPC)
+- One EC2 instance (Amazon Linux 2)
+- One RDS MySQL database
+
+## Structure
+
+```
+terraform-aws-iac/
+│
+├── main.tf
+├── provider.tf
+├── variables.tf
+├── terraform.tfvars
+├── outputs.tf
+├── modules/
+│   ├── vpc/
+│   ├── ec2/
+│   └── rds/
+```
+
+## Requirements
+
+- Terraform >= 1.0
+- AWS CLI with configured credentials
+
+## Usage
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```
+
+## Outputs
+
+- `vpc_id`: ID of the created VPC
+- `ec2_public_ip`: Public IP of the EC2 instance
+- `rds_endpoint`: RDS connection endpoint

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,18 @@
+module "vpc" {
+  source     = "./modules/vpc"
+  cidr_block = var.vpc_cidr
+}
+
+module "ec2" {
+  source    = "./modules/ec2"
+  vpc_id    = module.vpc.vpc_id
+  subnet_id = module.vpc.public_subnet_id
+}
+
+module "rds" {
+  source      = "./modules/rds"
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.private_subnet_ids
+  db_password = var.db_password
+  ec2_sg_id   = module.ec2.security_group_id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,11 @@
-output "endpoint" {
-  value = aws_db_instance.default.endpoint
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "ec2_public_ip" {
+  value = module.ec2.public_ip
+}
+
+output "rds_endpoint" {
+  value = module.rds.endpoint
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                   = var.region
+  shared_credentials_files = ["~/.aws/credentials"]
+  profile                  = "hernasoftserve"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,6 @@
+variable "region" {}
+variable "vpc_cidr" {}
+variable "db_password" {
+  description = "Password for RDS"
+  sensitive   = true
+}


### PR DESCRIPTION
Integrated Terraform modules in the root configuration.

The root `main.tf` now orchestrates:
- VPC module: creates the main networking infrastructure
- EC2 module: deploys a web instance in the public subnet
- RDS module: creates a private PostgreSQL DB accessible from the EC2 security group

All module inputs are wired correctly using outputs, and ready for deployment using `terraform apply`.

This completes the infrastructure integration across modules