### PR TITLE
WIP: fixing pass promt

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,9 +10,8 @@ module "ec2" {
 }
 
 module "rds" {
-  source      = "./modules/rds"
-  vpc_id      = module.vpc.vpc_id
-  subnet_ids  = module.vpc.private_subnet_ids
-  db_password = var.db_password
-  ec2_sg_id   = module.ec2.security_group_id
+  source     = "./modules/rds"
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnet_ids
+  ec2_sg_id  = module.ec2.security_group_id
 }

--- a/terraform/modules/rds/variables.tf
+++ b/terraform/modules/rds/variables.tf
@@ -2,10 +2,6 @@ variable "vpc_id" {}
 variable "subnet_ids" {
   type = list(string)
 }
-variable "db_password" {
-  description = "Password for the RDS PostgreSql instance"
-  sensitive   = true
-}
 
 variable "ec2_sg_id" {
   description = "Security group ID of EC2 instance"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,6 +1,2 @@
 variable "region" {}
 variable "vpc_cidr" {}
-variable "db_password" {
-  description = "Password for RDS"
-  sensitive   = true
-}


### PR DESCRIPTION
This pull request removes the now-unnecessary db_password variable from both the root module and the rds module, following the migration to AWS SSM Parameter Store for handling secrets.

We previously moved the database password management to AWS Systems Manager (SSM) for better security and encryption. This PR completes the transition by cleaning up leftover code.

Changes:
Removed db_password variable from:

terraform/variables.tf

terraform/modules/rds/variables.tf

Updated the rds module call in main.tf to exclude db_password input.
